### PR TITLE
修改多对多关联传入参数及部分逻辑

### DIFF
--- a/src/Relations/BelongsToMany.php
+++ b/src/Relations/BelongsToMany.php
@@ -14,18 +14,13 @@ use EasySwoole\ORM\AbstractModel;
 
 use EasySwoole\ORM\DbManager;
 use EasySwoole\ORM\Exception\Exception;
+use EasySwoole\ORM\Db\Config;
 
 class BelongsToMany
 {
-    /** @var AbstractModel */
     private $fatherModel;
-    /** @var AbstractModel */
-    private $childModel;
-
+    private $childModelName;
     private $middelTableName;
-
-    private $pk;
-    private $childPk;
 
 
     /**
@@ -38,72 +33,152 @@ class BelongsToMany
      * @throws Exception
      * @throws \ReflectionException
      */
-    public function __construct(AbstractModel $model, $class, $middleTableName, $pk = null, $childPk = null)
+    public function __construct(AbstractModel $model, $class, $middleTableName)
     {
-        $ref = new \ReflectionClass($class);
+        $this->fatherModel     = $model;
+        $this->childModelName  = $class;
+        $this->middelTableName = $middleTableName;
+    }
+
+    /**
+     * 直接查询，单条数据适用
+     * @param $where
+     * @param $foreignPivotKey
+     * @param $relatedPivotKey
+     * @param $parentKey
+     * @param $relatedKey
+     * @param $joinType
+     * @throws Exception
+     * @throws \Throwable
+     */
+    public function result($where, $foreignPivotKey, $relatedPivotKey, $parentKey, $relatedKey, $joinType)
+    {
+        $ref = new \ReflectionClass($this->childModelName);
 
         if (!$ref->isSubclassOf(AbstractModel::class)) {
             throw new Exception("relation class must be subclass of AbstractModel");
         }
 
-        $this->fatherModel     = $model;
-        $this->childModel      = new $class;
-        $this->middelTableName = $middleTableName;
+        /** @var AbstractModel $ins */
+        $ins = $ref->newInstance();
 
-        if ($pk!==null){
-            $this->pk = $pk;
-        }else{
-            $this->pk = $this->fatherModel->schemaInfo()->getPkFiledName();
+        if ($foreignPivotKey === null) {
+            $dbName = Config::getInstance()->getDatabase();
+            $queryBuilder = new QueryBuilder();
+            $queryBuilder->raw("SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE WHERE CONSTRAINT_SCHEMA='{$dbName}' AND TABLE_NAME='{$this->middelTableName}' AND REFERENCED_TABLE_NAME='{$this->fatherModel->schemaInfo()->getTable()}' AND CONSTRAINT_NAME like 'fk_%';");
+            $tableColumns = DbManager::getInstance()->query($queryBuilder, $raw = true, 'default');
+            if (!empty($tableColumns->getResult())) {
+                $foreignPivotKey = $tableColumns->getResult()[0]['COLUMN_NAME'];
+            } else {
+                return null;
+            }
         }
-        if ($childPk !== NULL) {
-            $this->childPk = $childPk;
-        } else {
-            $this->childPk = $this->childModel->schemaInfo()->getPkFiledName();
+        if ($relatedPivotKey === null) {
+            $dbName = Config::getInstance()->getDatabase();
+            $queryBuilder = new QueryBuilder();
+            $queryBuilder->raw("SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE WHERE CONSTRAINT_SCHEMA='{$dbName}' AND TABLE_NAME='{$this->middelTableName}' AND REFERENCED_TABLE_NAME='{$ins->schemaInfo()->getTable()}' AND CONSTRAINT_NAME like 'fk_%';");
+            $tableColumns = DbManager::getInstance()->query($queryBuilder, $raw = true, 'default');
+            if (!empty($tableColumns->getResult())) {
+                $relatedPivotKey = $tableColumns->getResult()[0]['COLUMN_NAME'];
+            } else {
+                return null;
+            }
         }
-    }
+        if ($parentKey === null) {
+            $parentKey = $this->fatherModel->schemaInfo()->getPkFiledName();
+        }
+        if ($relatedKey === null) {
+            $relatedKey = $ins->schemaInfo()->getPkFiledName();
+        }
 
-    /**
-     * 直接查询，单条数据适用
-     * @throws Exception
-     * @throws \Throwable
-     */
-    public function result()
-    {
-        $pk      = $this->pk;
-        $pkValue = $this->fatherModel->getAttr($pk);
-        $childPk = $this->childPk;
-
-        $queryBuilder = new QueryBuilder();
-        $queryBuilder->raw("SELECT $pk,$childPk FROM `{$this->middelTableName}` WHERE `{$pk}` = ? ", [$pkValue]);
-        $middleQuery = DbManager::getInstance()->query($queryBuilder, true, $this->fatherModel->getConnectionName());
+        $builder = new QueryBuilder();
+        $pkValue = $this->fatherModel->getAttr($parentKey);
+        $builder->raw("SELECT $foreignPivotKey,$relatedPivotKey FROM `{$this->middelTableName}` WHERE `{$foreignPivotKey}` = ? ", [$pkValue]);
+        $middleQuery = DbManager::getInstance()->query($builder, true, $this->fatherModel->getConnectionName());
 
         if (!$middleQuery->getResult()) return null;
 
         // in查询目标表
-        $childPkValue = array_column($middleQuery->getResult(), $childPk);
+        $childPkValue = array_column($middleQuery->getResult(), $relatedPivotKey);
 
-        $childRes = $this->childModel->all($childPkValue);
+        $childRes = $ins->all([$relatedKey => [$childPkValue, 'in']]);
 
         return $childRes;
     }
 
     /**
-     * @param $data
-     * @param $with
+     * @param array $data 原始数据 进入这里的处理都是多条 all查询结果
+     * @param $with string 预查询字段名
+     * @param $where
+     * @param $foreignPivotKey
+     * @param $relatedPivotKey
+     * @param $parentKey
+     * @param $relatedKey
+     * @param $joinType
+     * @return array
+     * @throws Exception
+     * @throws \Throwable
      */
-    public function preHandleWith($data, $with)
+    public function preHandleWith(array $data, $with, $where, $foreignPivotKey, $relatedPivotKey, $parentKey, $relatedKey, $joinType)
     {
+        // 如果闭包不为空，则只能执行闭包
+        if ($where !== null && is_callable($where)){
+            // 闭包的只能一个一个调用
+            foreach ($data as $model){
+                foreach ($this->fatherModel->getWith() as $with){
+                    $model->$with();
+                }
+            }
+            return $data;
+        }
+
+        $ref = new \ReflectionClass($this->childModelName);
+
+        if (!$ref->isSubclassOf(AbstractModel::class)) {
+            throw new Exception("relation class must be subclass of AbstractModel");
+        }
+
+        /** @var AbstractModel $ins */
+        $ins = $ref->newInstance();
+
+        if ($foreignPivotKey === null) {
+            $dbName = Config::getInstance()->getDatabase();
+            $queryBuilder = new QueryBuilder();
+            $queryBuilder->raw("SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE WHERE CONSTRAINT_SCHEMA='{$dbName}' AND TABLE_NAME='{$this->middelTableName}' AND REFERENCED_TABLE_NAME='{$this->fatherModel->schemaInfo()->getTable()}' AND CONSTRAINT_NAME like 'fk_%';");
+            $tableColumns = DbManager::getInstance()->query($queryBuilder, $raw = true, 'default');
+            if (!empty($tableColumns->getResult())) {
+                $foreignPivotKey = $tableColumns->getResult()[0]['COLUMN_NAME'];
+            } else {
+                return null;
+            }
+        }
+        if ($relatedPivotKey === null) {
+            $dbName = Config::getInstance()->getDatabase();
+            $queryBuilder = new QueryBuilder();
+            $queryBuilder->raw("SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE WHERE CONSTRAINT_SCHEMA='{$dbName}' AND TABLE_NAME='{$this->middelTableName}' AND REFERENCED_TABLE_NAME='{$ins->schemaInfo()->getTable()}' AND CONSTRAINT_NAME like 'fk_%';");
+            $tableColumns = DbManager::getInstance()->query($queryBuilder, $raw = true, 'default');
+            if (!empty($tableColumns->getResult())) {
+                $relatedPivotKey = $tableColumns->getResult()[0]['COLUMN_NAME'];
+            } else {
+                return null;
+            }
+        }
+        if ($parentKey === null) {
+            $parentKey = $this->fatherModel->schemaInfo()->getPkFiledName();
+        }
+        if ($relatedKey === null) {
+            $relatedKey = $ins->schemaInfo()->getPkFiledName();
+        }
+
         // 逻辑跟result方法中查询基本一致，先获取A表主键数组，从中间表中查询所有符合数据，映射成为二维数组
         // 从B表查询所有数据，根据映射数组设置到A模型数据中
-        $pk      = $this->pk;
-        $pkValue = array_map(function ($v) use ($pk){
-            return $v->$pk;
+        $pkValue = array_map(function ($v) use ($parentKey){
+            return $v->$parentKey;
         }, $data);
         $pkValueStr = implode(',', $pkValue);
-        $childPk = $this->childPk;
 
         $queryBuilder = new QueryBuilder();
-        $queryBuilder->raw("SELECT $pk,$childPk FROM `{$this->middelTableName}` WHERE `{$pk}` IN ({$pkValueStr}) ");
+        $queryBuilder->raw("SELECT $foreignPivotKey,$relatedPivotKey FROM `{$this->middelTableName}` WHERE `{$foreignPivotKey}` IN ({$pkValueStr}) ");
         $middleQuery = DbManager::getInstance()->query($queryBuilder, true, $this->fatherModel->getConnectionName());
 
         if (!$middleQuery->getResult()) return $data;
@@ -111,17 +186,17 @@ class BelongsToMany
         $middleDataArray = [];
         $BPkValue = []; // 用于一会IN查询B表
         foreach ($middleQuery->getResult() as $queryData) {
-            $APkValue                     = $queryData[$pk];
-            $middleDataArray[$APkValue][] = $queryData[$childPk];
-            $BPkValue[]                   = $queryData[$childPk];
+            $APkValue                     = $queryData[$foreignPivotKey];
+            $middleDataArray[$APkValue][] = $queryData[$relatedPivotKey];
+            $BPkValue[]                   = $queryData[$relatedPivotKey];
         }
         // BPK去重 重置下标
         $BPkValue = array_values(array_unique($BPkValue));
-        $BValue   = $this->childModel->all($BPkValue);
+        $BValue   = $ins->all([$relatedKey => [$BPkValue, 'in']]);
         // 映射为以BPK为键的数组
         $BValueByBPK = [];
         foreach ($BValue as $B){
-            $BValueByBPK[$B->$childPk] = $B;
+            $BValueByBPK[$B->$relatedKey] = $B;
         }
 
         // 更新中间二维数组，把pk值映射成model
@@ -137,8 +212,8 @@ class BelongsToMany
 
         // 遍历$data 原始数据，把属于自己的数据放到自己的属性中
         foreach ($data as $model){
-            if (isset($middleDataArray[$model->$pk])){
-                $model[$with] = $middleDataArray[$model->$pk];
+            if (isset($middleDataArray[$model->$parentKey])){
+                $model[$with] = $middleDataArray[$model->$parentKey];
             }
         }
         return $data;

--- a/src/Relations/BelongsToMany.php
+++ b/src/Relations/BelongsToMany.php
@@ -14,7 +14,6 @@ use EasySwoole\ORM\AbstractModel;
 
 use EasySwoole\ORM\DbManager;
 use EasySwoole\ORM\Exception\Exception;
-use EasySwoole\ORM\Db\Config;
 
 class BelongsToMany
 {
@@ -63,7 +62,7 @@ class BelongsToMany
         $ins = $ref->newInstance();
 
         if ($foreignPivotKey === null) {
-            $dbName = Config::getInstance()->getDatabase();
+            $dbName = DbManager::getInstance()->getConnection()->getConfig()->getDatabase();
             $queryBuilder = new QueryBuilder();
             $queryBuilder->raw("SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE WHERE CONSTRAINT_SCHEMA='{$dbName}' AND TABLE_NAME='{$this->middelTableName}' AND REFERENCED_TABLE_NAME='{$this->fatherModel->schemaInfo()->getTable()}' AND CONSTRAINT_NAME like 'fk_%';");
             $tableColumns = DbManager::getInstance()->query($queryBuilder, $raw = true, 'default');
@@ -74,7 +73,7 @@ class BelongsToMany
             }
         }
         if ($relatedPivotKey === null) {
-            $dbName = Config::getInstance()->getDatabase();
+            $dbName = DbManager::getInstance()->getConnection()->getConfig()->getDatabase();
             $queryBuilder = new QueryBuilder();
             $queryBuilder->raw("SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE WHERE CONSTRAINT_SCHEMA='{$dbName}' AND TABLE_NAME='{$this->middelTableName}' AND REFERENCED_TABLE_NAME='{$ins->schemaInfo()->getTable()}' AND CONSTRAINT_NAME like 'fk_%';");
             $tableColumns = DbManager::getInstance()->query($queryBuilder, $raw = true, 'default');
@@ -142,7 +141,7 @@ class BelongsToMany
         $ins = $ref->newInstance();
 
         if ($foreignPivotKey === null) {
-            $dbName = Config::getInstance()->getDatabase();
+            $dbName = DbManager::getInstance()->getConnection()->getConfig()->getDatabase();
             $queryBuilder = new QueryBuilder();
             $queryBuilder->raw("SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE WHERE CONSTRAINT_SCHEMA='{$dbName}' AND TABLE_NAME='{$this->middelTableName}' AND REFERENCED_TABLE_NAME='{$this->fatherModel->schemaInfo()->getTable()}' AND CONSTRAINT_NAME like 'fk_%';");
             $tableColumns = DbManager::getInstance()->query($queryBuilder, $raw = true, 'default');
@@ -153,7 +152,7 @@ class BelongsToMany
             }
         }
         if ($relatedPivotKey === null) {
-            $dbName = Config::getInstance()->getDatabase();
+            $dbName = DbManager::getInstance()->getConnection()->getConfig()->getDatabase();
             $queryBuilder = new QueryBuilder();
             $queryBuilder->raw("SELECT COLUMN_NAME FROM INFORMATION_SCHEMA.KEY_COLUMN_USAGE WHERE CONSTRAINT_SCHEMA='{$dbName}' AND TABLE_NAME='{$this->middelTableName}' AND REFERENCED_TABLE_NAME='{$ins->schemaInfo()->getTable()}' AND CONSTRAINT_NAME like 'fk_%';");
             $tableColumns = DbManager::getInstance()->query($queryBuilder, $raw = true, 'default');

--- a/tests/models/Users.php
+++ b/tests/models/Users.php
@@ -17,6 +17,7 @@ class Users extends AbstractModel
 
     public function roles()
     {
-        return $this->belongsToMany(Roles::class, 'user_role');
+		// 被关联模型--关联的中间表--筛选条件--中间表中本模型外键名--中间表中子模型外键名--本模型主键名--子模型主键名--关联关系
+        return $this->belongsToMany(Roles::class, 'user_role', null, 'user_id', 'role_id', 'user_id', 'role_id');
     }
 }


### PR DESCRIPTION
改动原因：关联字段不够用，目前中间关联表的字段被固定了，默认是取被关联两表的主键（我的是id），未取关联中间表的外键（user_id、role_id），若不相同则导致关联不到对应表。
修改内容：传入参数（被关联模型--关联的中间表--筛选条件--中间表中本模型外键名--中间表中子模型外键名--本模型主键名--子模型主键名--关联关系）。
特殊注明：并经过了phpunit的测试（./vendor/bin/co-phpunit tests/BelongsToManyTest.php）。目前仅实现了结果关联显示。筛选条件、关联关系仅提供了入口，未加入实施代码，有待后期完善。