### PR TITLE
Host port

### DIFF
--- a/src/Db/Config.php
+++ b/src/Db/Config.php
@@ -39,7 +39,7 @@ class Config extends \EasySwoole\Pool\Config
             $this->host = $host;
         }else{
             $this->host = substr($host, 0, $index);
-            $this->port = substr($host, $index + 1);
+            $this->port = intval(substr($host, $index + 1));
         }
         return $this;        
     }

--- a/src/Db/Config.php
+++ b/src/Db/Config.php
@@ -34,8 +34,14 @@ class Config extends \EasySwoole\Pool\Config
      */
     public function setHost($host): Config
     {
-        $this->host = $host;
-        return $this;
+        $index = strpos($host, ':');
+        if($index === false){
+            $this->host = $host;
+        }else{
+            $this->host = substr($host, 0, $index);
+            $this->port = substr($host, $index + 1);
+        }
+        return $this;        
     }
 
     /**


### PR DESCRIPTION
之前用腾讯云的云数据库，数据库地址带着端口号，复制过来试了下不行，要手动setPort，希望能和tp一样支持带端口号的host地址，比如说，47.111.23.15:8010，在setHost中设置后，自动设置好host和port，不需要手动setPort